### PR TITLE
fixes and updates

### DIFF
--- a/cmd/easygen/main.go
+++ b/cmd/easygen/main.go
@@ -47,7 +47,7 @@ func init() {
 	flag.StringVar(&easygen.Opts.TemplateStr, "ts", "",
 		"template string (in text)")
 	flag.StringVar(&easygen.Opts.TemplateFile, "tf", "",
-		".tmpl template file `name` (default: same as .yaml file)")
+		".tmpl (comma-separated) template file `name(s)` (default: same as .yaml file)")
 	flag.StringVar(&easygen.Opts.ExtYaml, "ey", ".yaml",
 		"`extension` of yaml file")
 	flag.StringVar(&easygen.Opts.ExtTmpl, "et", ".tmpl",

--- a/cmd/easygen/main.go
+++ b/cmd/easygen/main.go
@@ -95,11 +95,12 @@ func main() {
 	flag.Parse()
 
 	// One mandatory non-flag arguments
-	if len(flag.Args()) < 1 {
+	if flag.NArg() < 1 {
 		easygen.Usage()
 	}
-	fileName := flag.Args()[0]
 	easygen.TFStringsInit()
 
-	fmt.Print(easygen.Generate(easygen.Opts.HTML, fileName))
+	for _, fileName := range flag.Args() {
+		fmt.Print(easygen.Generate(easygen.Opts.HTML, fileName))
+	}
 }

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var Opts = Options{ExtYaml: ".yaml", ExtTmpl: ".tmpl"}
 // Usage function shows help on commandline usage
 func Usage() {
 	fmt.Fprintf(os.Stderr,
-		"\nUsage:\n %s [flags] YamlFileName\n\nFlags:\n\n",
+		"\nUsage:\n %s [flags] YamlFileName [YamlFileName...]\n\nFlags:\n\n",
 		progname)
 	flag.PrintDefaults()
 	fmt.Fprintf(os.Stderr,

--- a/easygen.go
+++ b/easygen.go
@@ -114,33 +114,42 @@ func Generate(HTML bool, fileName string) string {
 // function, dictated by the first parameter "HTML".
 // By Matt Harden @gmail.com
 func ParseFiles(HTML bool, filenames ...string) (template, error) {
-	tname := filepath.Base(filenames[0])
+	var tname string
 
-	// use text template
-	funcMapHT := ht.FuncMap{
-		"minus1": minus1,
-		"cls2lc": cls2lc.String,
-		"cls2uc": cls2uc.String,
-		"cls2ss": cls2ss.String,
-		"ck2lc":  ck2lc.String,
-		"ck2uc":  ck2uc.String,
-		"ck2ls":  ck2ls.String,
-		"ck2ss":  ck2ss.String,
-		"clc2ss": clc2ss.String,
-		"cuc2ss": cuc2ss.String,
+	if len(Opts.TemplateStr) > 0 {
+		if HTML {
+			tname = "HT"
+		} else {
+			tname = "TT"
+		}
+	} else if len(filenames) == 0 {
+		return nil, fmt.Errorf("ParseFiles called without template filename")
+	} else {
+		tname = filepath.Base(filenames[0])
 	}
-
-	_ = funcMapHT
 
 	if HTML {
 		// use html template
-		t, err := ht.ParseFiles(filenames...)
-		//t, err := ht.New("HT").Funcs(funcMapHT).ParseFiles(filenames...)
-		return t, err
+		htmlTemplate := ht.New(tname).Funcs(ht.FuncMap{
+			"minus1": minus1,
+			"cls2lc": cls2lc.String,
+			"cls2uc": cls2uc.String,
+			"cls2ss": cls2ss.String,
+			"ck2lc":  ck2lc.String,
+			"ck2uc":  ck2uc.String,
+			"ck2ls":  ck2ls.String,
+			"ck2ss":  ck2ss.String,
+			"clc2ss": clc2ss.String,
+			"cuc2ss": cuc2ss.String,
+		})
+		if len(Opts.TemplateStr) > 0 {
+			return htmlTemplate.Parse(Opts.TemplateStr)
+		}
+		return htmlTemplate.ParseFiles(filenames...)
 	}
 
 	// use text template
-	funcMap := tt.FuncMap{
+	textTemplate := tt.New(tname).Funcs(tt.FuncMap{
 		"eqf":      strings.EqualFold,
 		"split":    strings.Fields,
 		"minus1":   minus1,
@@ -155,15 +164,12 @@ func ParseFiles(HTML bool, filenames ...string) (template, error) {
 		"ck2ss":    ck2ss.String,
 		"clc2ss":   clc2ss.String,
 		"cuc2ss":   cuc2ss.String,
-	}
+	})
 
 	if len(Opts.TemplateStr) > 0 {
-		t, err := tt.New("TT").Funcs(funcMap).Parse(Opts.TemplateStr)
-		return t, err
+		return textTemplate.Parse(Opts.TemplateStr)
 	}
-
-	t, err := tt.New(tname).Funcs(funcMap).ParseFiles(filenames...)
-	return t, err
+	return textTemplate.ParseFiles(filenames...)
 }
 
 // Exit if error occurs

--- a/easygen.go
+++ b/easygen.go
@@ -178,7 +178,7 @@ func ParseFiles(HTML bool, filenames ...string) (template, error) {
 // Exit if error occurs
 func checkError(err error) {
 	if err != nil {
-		fmt.Printf("[%s] Fatal error - %s\n", progname, err)
+		fmt.Fprintf(os.Stderr, "[%s] Fatal error - %s\n", progname, err)
 		os.Exit(1)
 	}
 }

--- a/easygen.go
+++ b/easygen.go
@@ -65,7 +65,26 @@ func Generate0(HTML bool, strTempl string, fileName string) string {
 
 // Generate will produce output from the template according to the corresponding driving data, fileName is for both template and data file name
 func Generate(HTML bool, fileName string) string {
-	source, err := ioutil.ReadFile(fileName + Opts.ExtYaml)
+	var fileNameT string // Name of the template file
+
+	// Allow to use fileName with and without the @Opts.ExtYaml suffix.
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		fileName += Opts.ExtYaml
+	}
+
+	// Allow to use @Opts.TemplateFile without the @Opts.ExtTmpl suffix.
+	if len(Opts.TemplateFile) > 0 {
+		fileNameT = Opts.TemplateFile
+		if _, err := os.Stat(fileNameT); os.IsNotExist(err) {
+			fileNameT += Opts.ExtTmpl
+		}
+	} else if idx := strings.LastIndex(fileName, "."); idx > 0 {
+		fileNameT = fileName[:idx] + Opts.ExtTmpl
+	} else {
+		fileNameT = fileName + Opts.ExtTmpl
+	}
+
+	source, err := ioutil.ReadFile(fileName)
 	checkError(err)
 
 	m := make(map[interface{}]interface{})
@@ -81,13 +100,7 @@ func Generate(HTML bool, fileName string) string {
 	m["ENV"] = env
 	//fmt.Printf("] %+v\n", m)
 
-	// template file name
-	fileNameT := fileName
-	if len(Opts.TemplateFile) > 0 {
-		fileNameT = Opts.TemplateFile
-	}
-
-	t, err := ParseFiles(HTML, fileNameT+Opts.ExtTmpl)
+	t, err := ParseFiles(HTML, fileNameT)
 	checkError(err)
 
 	buf := new(bytes.Buffer)

--- a/easygen.go
+++ b/easygen.go
@@ -156,7 +156,7 @@ func ParseFiles(HTML bool, filenames ...string) (template, error) {
 // Exit if error occurs
 func checkError(err error) {
 	if err != nil {
-		fmt.Printf("[%s] Fatal error - %v", progname, err.Error())
+		fmt.Printf("[%s] Fatal error - %s\n", progname, err)
 		os.Exit(1)
 	}
 }

--- a/easygen.go
+++ b/easygen.go
@@ -47,10 +47,14 @@ type template interface {
 ////////////////////////////////////////////////////////////////////////////
 // Function definitions
 
-// Generate2 will produce output according to the given template and driving data files, specified via fileNameTempl and fileName (for data) respectively
-func Generate2(HTML bool, fileNameTempl string, fileName string) string {
+// Generate2 will produce output according to the given template and driving data files,
+// specified via fileNameTempl and fileNames (for data) respectively.
+func Generate2(HTML bool, fileNameTempl string, fileNames ...string) (ret string) {
 	Opts.TemplateFile = fileNameTempl
-	ret := Generate(HTML, fileName)
+
+	for _, fileName := range fileNames {
+		ret += Generate(HTML, fileName)
+	}
 	Opts.TemplateFile = ""
 	return ret
 }

--- a/easygen_test.go
+++ b/easygen_test.go
@@ -216,6 +216,67 @@ func ExampleGenerate_commandLineCobraViperInit() {
 }
 
 ////////////////////////////////////////////////////////////////////////////
+// Enums
+// Test running the same input .yaml file with multiple templates.
+func ExampleEnumMultipleTemplates() {
+	// Equivalent testing on commandline:
+	// easygen -tf test/enum_c-header,test/enum_c-source  test/raid_type.yaml
+	fmt.Print(easygen.Generate2(false, "test/enum_c-header,test/enum_c-source", "test/raid_type.yaml"))
+	// Output:
+	// // Simplified enumeration of available RAID devices
+	// enum raid_type {
+	// 	RAID0 = 100,
+	// 	RAID1,
+	// };
+	//
+	// /** Try to extract an enum raid_type value from @str; fall back to "RAID0". */
+	// const enum raid_type
+	// str_to_raid_type(const char * const *str)
+	// {
+	// 	if (strcasecmp(str, "RAID0") == 0) {
+	// 		return RAID0;
+	// 	} else if (strcasecmp(str, "RAID-0") == 0) {
+	// 		return RAID0;
+	// 	} else if (strcasecmp(str, "RAID1") == 0) {
+	// 		return RAID1;
+	// 	} else if (strcasecmp(str, "RAID-1") == 0) {
+	// 		return RAID1;
+	// 	}
+	// 	return RAID0;
+	// }
+	//
+	// /** Stringer function for raid_type. */
+	// const char *
+	// raid_type_to_str(const enum raid_type val)
+	// {
+	// 	switch (val) {
+	// 	case RAID0:
+	// 		return "RAID0";
+	// 	case RAID1:
+	// 		return "RAID1";
+	// 	}
+	// }
+}
+
+// Test running the same input .tmpl template file with multiple .yaml inputs.
+func ExampleEnumMultipleInputs() {
+	// Equivalent testing on commandline:
+	// easygen -tf test/enum_c-header test/raid_type test/raid_driver
+	fmt.Print(easygen.Generate2(false, "test/enum_c-header", "test/raid_type", "test/raid_driver"))
+	// Output:
+	// // Simplified enumeration of available RAID devices
+	// enum raid_type {
+	// 	RAID0 = 100,
+	// 	RAID1,
+	// };
+	//
+	// enum raid_driver {
+	// 	HW,
+	// 	SW,
+	// };
+}
+
+////////////////////////////////////////////////////////////////////////////
 // Varible Names
 
 func ExampleVaribleNames() {

--- a/test/commandlineFlag.yaml
+++ b/test/commandlineFlag.yaml
@@ -36,7 +36,7 @@ Options:
     Type: string
     Flag: tf
     Value: '""'
-    Usage: ".tmpl template file `name` (default: same as .yaml file)"
+    Usage: ".tmpl (comma-separated) template file `name(s)` (default: same as .yaml file)"
 
   - Name: ExtYaml
     Type: string
@@ -71,7 +71,7 @@ Options:
 # Whether to use the USAGE_SUMMARY in Usage help
 UsageSummary: ""
 
-UsageLead: "\\nUsage:\\n %s [flags] YamlFileName\\n\\nFlags:\\n\\n"
+UsageLead: "\\nUsage:\\n %s [flags] YamlFileName [YamlFileName...]\\n\\nFlags:\\n\\n"
 
-UsageEnd: "\\nYamlFileName: The name for the .yaml data and .tmpl template file\\n\\tOnly the name part, without extension. Can include the path as well.\\n"
+UsageEnd: "\\nYamlFileName(s): The name for the .yaml data and .tmpl template file\\n\\tOnly the name part, without extension. Can include the path as well.\\n"
 

--- a/test/enum_c-header.tmpl
+++ b/test/enum_c-header.tmpl
@@ -1,0 +1,19 @@
+{{- if .EnumComments -}}
+  {{- range .EnumComments }}
+// {{.}}
+  {{- end -}}
+{{- end }}
+enum {{.EnumName}} {
+{{- range $i, $val := .Values -}}
+  {{- if .Comment }}
+  {{- if gt $i 0 }}
+  {{ end }}
+	// {{.Comment}}
+  {{- end -}}
+  {{- if .Value }}
+	{{ .Name }} = {{.Value }},
+  {{- else }}
+	{{ .Name }},
+  {{- end -}}
+{{- end }}
+};

--- a/test/enum_c-source.tmpl
+++ b/test/enum_c-source.tmpl
@@ -1,0 +1,35 @@
+{{/*
+   Randomly pick the first element if no EnumDefault is set.
+*/}}
+{{ with $DEFAULT := or (.EnumDefault) (index .Values 0 "Name") -}}
+/** Try to extract an enum {{$.EnumName}} value from @str; fall back to "{{$DEFAULT}}". */
+const enum {{$.EnumName}}
+str_to_{{$.EnumName}}(const char * const *str)
+{
+{{- range $i, $val := $.Values }}
+	{{ if gt $i 0 -}}} else {{end -}}if (strcasecmp(str, "{{ if .String }}{{.String}}{{else}}{{.Name}}{{end}}") == 0) {
+		return {{ .Name }};
+{{- range .AltString }}
+	} else if (strcasecmp(str, "{{.}}") == 0) {
+		return {{ $val.Name }};
+{{- end }}
+{{- if eq (len $.Values|minus1) ($i)}}{{/* Sentinel */}}
+	}
+{{- end -}}
+{{- end }}
+	return {{$DEFAULT}};
+}
+{{- end }}
+
+/** Stringer function for {{.EnumName}}. */
+const char *
+{{.EnumName}}_to_str(const enum {{.EnumName}} val)
+{
+	switch (val) {
+{{- range .Values }}
+	case {{.Name}}:
+		return "{{ if .String }}{{.String}}{{else}}{{.Name}}{{end}}";
+{{- end }}
+	}
+}
+

--- a/test/raid_driver.yaml
+++ b/test/raid_driver.yaml
@@ -1,0 +1,7 @@
+EnumName: raid_driver
+
+Values:
+  - Name: HW
+    String: "Hardware-RAID"
+  - Name: SW
+    String: "Software-RAID"

--- a/test/raid_type.yaml
+++ b/test/raid_type.yaml
@@ -1,0 +1,19 @@
+# EnumName is the type of the Enum in C (Java/Go will use CamelCase)
+EnumName: raid_type
+
+# EnumComments contain documentation that goes above @EnumName
+EnumComments:
+  - Simplified enumeration of available RAID devices
+
+# List of enum values
+Values:
+  - Name: RAID0
+    String: "RAID0"          # stringified value (defaults to @Name as string)
+    Value: 100
+    AltString: [ "RAID-0" ]  # list of alternatives that translate into @Value
+
+  - Name: RAID1
+    AltString: [ "RAID-1" ]
+
+# The default value to return if nothing else is known
+EnumDefault: RAID0


### PR DESCRIPTION
Thank you for this really useful tool. It is so powerful.

While working on templates, I ran into limitations, please find attached
* when printing error messages, add a newline (`\n`),
* allow the user to also add the `.yaml` `.tmpl` suffixes to files, without breaking existing usage,
* allow to run the same template on multiple `.yaml` inputs,
* allow to run multiple templates on on the same `.yaml` input,
* fix some problems with the html/text template parser.