### PR TITLE
Resolves #6

### DIFF
--- a/easygen.go
+++ b/easygen.go
@@ -72,7 +72,10 @@ func Generate(HTML bool, fileName string) string {
 	var templates []string
 
 	// Allow to use fileName with and without the @Opts.ExtYaml suffix.
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+	// If both <file>.yaml and <file> exist, prefer <file>.yaml.
+	if _, err := os.Stat(fileName + Opts.ExtYaml); err == nil {
+		fileName += Opts.ExtYaml
+	} else if _, err = os.Stat(fileName); os.IsNotExist(err) {
 		fileName += Opts.ExtYaml
 	}
 


### PR DESCRIPTION
If both `file` and `file.yaml` exist, prefer the one with the
full extension, to avoid accidentally picking up binary files.