### PR TITLE
Fix typo in README: "Unbuntu" → "Ubuntu"

### DIFF
--- a/README.e.md
+++ b/README.e.md
@@ -29,7 +29,7 @@ Note this document is for `{{.Name}}` versions 4.0+. For historic versions check
 
 ## Install
 
-### Install as Debian/Unbuntu package
+### Install as Debian/Ubuntu package
 
 
     apt install {{.Name}}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   - [Usage](#usage)
     - [$ easygen](#-easygen)
   - [Install](#install)
-    - [Install as Debian/Unbuntu package](#install-as-debianunbuntu-package)
+    - [Install as Debian/Ubuntu package](#install-as-debianunbuntu-package)
     - [Install from source](#install-from-source)
   - [Test](#test)
   - [Details](#details)
@@ -80,7 +80,7 @@ Flag defaults can be overridden by corresponding environment variable, e.g.:
 
 ## Install
 
-### Install as Debian/Unbuntu package
+### Install as Debian/Ubuntu package
 
 
     apt install easygen


### PR DESCRIPTION
Thanks!