### PR TITLE
Break up the Go flag template init() function, fixes #33

### DIFF
--- a/test/commandlineFlag.ref
+++ b/test/commandlineFlag.ref
@@ -36,7 +36,7 @@ var Opts Options
 ////////////////////////////////////////////////////////////////////////////
 // Commandline definitions
 
-func init() {
+func initVars() {
 
 	// set default values for command line parameters
 	flag.BoolVar(&Opts.HTML, "html", false,
@@ -59,7 +59,9 @@ func init() {
 		"debugging `level`")
 	flag.IntVar(&Opts.Debug, "debug", 0,
 		"debugging `level`")
+}
 
+func initVals() {
 	exists := false
 	// Now override those default values from environment variables
 	if _, exists = os.LookupEnv("EASYGEN_HTML"); Opts.HTML|| exists {

--- a/test/commandlineFlag.tmpl
+++ b/test/commandlineFlag.tmpl
@@ -29,7 +29,7 @@ var {{.StructVar}} {{.StructName}}
 ////////////////////////////////////////////////////////////////////////////
 // Commandline definitions
 
-func init() {
+func initVars() {
 
 	// set default values for command line parameters{{range .Options}}{{if eq .Name "SEPARATOR" }}
 
@@ -38,7 +38,9 @@ func init() {
 		"{{$cf.Usage}}"){{end}}{{else}}
 	flag.{{clk2uc .Type}}Var(&{{$.StructVar}}.{{.Name}}, "{{.Flag}}", {{.Value}},
 		"{{.Usage}}"){{end}}{{end}}{{end}}
+}
 
+func initVals() {
 	exists := false
 	// Now override those default values from environment variables{{range .Options}}{{if eq .Name "SEPARATOR" }}
 


### PR DESCRIPTION
Details in #33.
